### PR TITLE
[Alpha] Add on_success and on_failure callbacks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
           hide_complexity: true
           indicators: true
           output: both
-          thresholds: '70 80'
+          thresholds: '80 80'
 
       - name: Add Coverage PR Comment
         uses: marocchino/sticky-pull-request-comment@v2

--- a/README.md
+++ b/README.md
@@ -11,6 +11,121 @@ This project is an extremely-lightweight task-runner exclusively for __async Pyt
 pip install "boilermaker-servicebus"
 ```
 
+## How to Use
+
+The `Boilermaker` application object requires some state (which will get sent to all handlers as the first argument upon invocation) and an authenticated ServiceBus client.
+
+In our primary app, we may have some code like the following:
+
+```python
+from azure.identity.aio import DefaultAzureCredential
+from azure.servicebus.aio import ServiceBusSender
+
+from boilermaker.app import Boilermaker
+from boilermaker import retries
+
+
+# This represents our "App" object
+class App:
+    def __init__(self, data):
+        self.data = data
+
+
+# This is a background task that we'll register
+async def background_task1(state, somearg, somekwarg=True):
+    """`state` must be first argument."""
+    await state.data.get("key")
+    print(state)
+    print(somearg)
+    print(somekwarg)
+
+
+azure_identity_async_credential = DefaultAzureCredential()
+service_bus_namespace_url = os.environ["SERVICE_BUS_NAMESPACE_URL"]
+service_bus_queue_name = os.environ["SERVICE_BUS_QUEUE_NAME"]
+
+# We create a service bus Sender client
+sbus_client = AzureServiceBus(
+    service_bus_namespace_url,
+    service_bus_queue_name,
+    azure_identity_async_credential,  # type: DefaultAzureCredential
+)
+
+# Next we'll create a worker and register our task
+worker = Boilermaker(App({"key": "value"}), service_bus_client=service_bus_client)
+worker.register_async(background_task1, policy=retries.RetryPolicy.default())
+
+
+# Finally, this will schedule the task
+async def publish_task():
+    await worker.apply_async(
+        background_task1, "first-arg", somekwarg=False
+    )
+
+if __name__ == "__main__":
+    asyncio.run(publish_task())
+```
+
+In another process, we'll need to *run* a background task worker. That looks like this:
+
+```python
+async def run_worker():
+    await worker.run()
+```
+
+If we look in , we should be able to see this task registered and run:
+
+```sh
+
+
+```
+
+
+## Callbacks and Retries
+
+It is possible to register callbacks for tasks, which can run on success or failure. To schedule a task with callbacks, we have to create a task object and then set a success and/or failure callback. Finally, instead of `apply_async` we have to call `publish_task`:
+
+```python
+async def a_background_task(state, param: int):
+    if param > 0:
+        print("Things seem to be going really well")
+        return None
+    raise ValueError("Negative numbers are a bummer")
+
+
+async def happy_path(state):
+    print("Everything is great!")
+
+
+async def sad_path(state):
+    print("Everything is sad")
+
+
+# We need to be sure our tasks are registered
+worker.register_async(a_background_task, policy=retries.NoRetry)
+worker.register_async(happy_path, policy=retries.NoRetry)
+worker.register_async(sad_path, policy=retries.NoRetry)
+
+# Now we can create a happy task and add callbacks
+happy_task = worker.create_task(a_background_task, 11)
+# This callback should get scheduled
+happy_task.on_success = worker.create_task(happy_path)
+# This callback will not
+happy_task.on_failure = worker.create_task(sad_path)
+
+# For good measure, we'll create a sad task too
+sad_task = worker.create_task(a_background_task, -20)
+# This callback should not get scheduled
+sad_task.on_success = worker.create_task(happy_path)
+# This callback should get scheduled
+sad_task.on_failure = worker.create_task(sad_path)
+
+# Finally, this will schedule the tasks
+async def publish_task():
+    await worker.publish_task(happy_task)
+    await worker.publish_task(sad_task)
+
+```
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -90,10 +90,14 @@ It is possible to register callbacks for tasks, which can run on success or fail
 ```python
 ...see worker-instantation example above...
 
-async def a_background_task(state, param: int):
-    if param > 0:
+from boilermaker.failure import TaskFailureResult
+
+async def a_background_task(state, param: str):
+    if param == "success":
         print("Things seem to be going really well")
         return None
+    elif param == "fail":
+        return TaskFailureResult
     raise ValueError("Negative numbers are a bummer")
 
 
@@ -111,14 +115,14 @@ worker.register_async(happy_path, policy=retries.NoRetry())
 worker.register_async(sad_path, policy=retries.NoRetry())
 
 # Now we can create a happy task and add callbacks
-happy_task = worker.create_task(a_background_task, 11)
+happy_task = worker.create_task(a_background_task, "success")
 # This callback should get scheduled
 happy_task.on_success = worker.create_task(happy_path)
 # This callback will not
 happy_task.on_failure = worker.create_task(sad_path)
 
 # For good measure, we'll create a sad task too
-sad_task = worker.create_task(a_background_task, -20)
+sad_task = worker.create_task(a_background_task, "uh oh!")
 # This callback should not get scheduled
 sad_task.on_success = worker.create_task(happy_path)
 # This callback should get scheduled

--- a/README.md
+++ b/README.md
@@ -15,7 +15,22 @@ pip install "boilermaker-servicebus"
 
 The `Boilermaker` application object requires some state (which will get sent to all handlers as the first argument upon invocation) and an authenticated ServiceBus client.
 
-In our primary app, we may have some code like the following:
+A task handler for `Boilermaker` is any async function which takes as its first argument application state and which has been registered:
+
+```sh
+# This is a background task that we'll register
+async def background_task1(state, somearg, somekwarg=True):
+    """`state` must be first argument."""
+    await state.data.get("key")
+    print(state)
+    print(somearg)
+    print(somekwarg)
+
+boilermaker_app.register_async(background_task1, policy=...A retry policy goes here...)
+```
+**Note**: `Boilermaker` does not currently have a way to store or use the results of tasks, and all arguments must be JSON-serializable.
+
+For a fuller example, in our application, we may have some code like the following:
 
 ```python
 from azure.identity.aio import DefaultAzureCredential
@@ -98,7 +113,7 @@ async def a_background_task(state, param: str):
         return None
     elif param == "fail":
         return TaskFailureResult
-    raise ValueError("Negative numbers are a bummer")
+    raise ValueError("Exceptions are a bummer!")
 
 
 async def happy_path(state):

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ If we look in , we should be able to see this task registered and run:
 It is possible to register callbacks for tasks, which can run on success or failure. To schedule a task with callbacks, we have to create a task object and then set a success and/or failure callback. Finally, instead of `apply_async` we have to call `publish_task`:
 
 ```python
+...see worker-instantation example above...
+
 async def a_background_task(state, param: int):
     if param > 0:
         print("Things seem to be going really well")
@@ -103,8 +105,8 @@ async def sad_path(state):
 
 # We need to be sure our tasks are registered
 worker.register_async(a_background_task, policy=retries.NoRetry)
-worker.register_async(happy_path, policy=retries.NoRetry)
-worker.register_async(sad_path, policy=retries.NoRetry)
+worker.register_async(happy_path, policy=retries.NoRetry())
+worker.register_async(sad_path, policy=retries.NoRetry())
 
 # Now we can create a happy task and add callbacks
 happy_task = worker.create_task(a_background_task, 11)
@@ -123,8 +125,9 @@ sad_task.on_failure = worker.create_task(sad_path)
 # Finally, this will schedule the tasks
 async def publish_task():
     await worker.publish_task(happy_task)
+    # If we wait a bit we can see more clearly one task before the other
+    await asyncio.sleep(4)
     await worker.publish_task(sad_task)
-
 ```
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -73,11 +73,13 @@ async def run_worker():
     await worker.run()
 ```
 
-If we look in , we should be able to see this task registered and run:
+If we look in the logs for our other process, we should be able to see this task registered and run:
 
 ```sh
-
-
+{"event": "Registered background function fn=background_task1", "level": "info", "logger": "boilermaker.app", "timestamp": "2024/12/10 15:46:54"}
+{"event": "[background_task1] Begin Task sequence_number=19657", "level": "info", "logger": "boilermaker.app", "timestamp": "2024/12/10 15:52:23"}
+...prints-go-here...
+{"event": "[background_task1] Completed Task sequence_number=19657 in 0.00021130498498678207s", "level": "info", "logger": "boilermaker.app", "timestamp": "2024/12/10 15:52:23"}
 ```
 
 
@@ -129,6 +131,26 @@ async def publish_task():
     await asyncio.sleep(4)
     await worker.publish_task(sad_task)
 ```
+
+Here are examples of log out from running the above:
+
+```json
+// Logs from registering the functions
+{"event": "Registered background function fn=callback_task_test", "level": "info", "logger": "boilermaker.app", "timestamp": "2024/12/10 15:46:54"}
+{"event": "Registered background function fn=happy_path", "level": "info", "logger": "boilermaker.app", "timestamp": "2024/12/10 15:46:54"}
+{"event": "Registered background function fn=sad_path", "level": "info", "logger": "boilermaker.app", "timestamp": "2024/12/10 15:46:54"}
+// Happy path test ->
+{"event": "[callback_task_test] Begin Task sequence_number=19657", "version": "pr72-0.25.1", "level": "info", "logger": "boilermaker.app", "timestamp": "2024/12/10 15:52:23"}
+{"event": "[callback_task_test] Completed Task sequence_number=19657 in 0.00021130498498678207s", "level": "info", "logger": "boilermaker.app", "timestamp": "2024/12/10 15:52:23"}
+{"event": "[happy_path] Begin Task sequence_number=19659", "level": "info", "logger": "boilermaker.app", "timestamp": "2024/12/10 15:52:24"}
+{"event": "[happy_path] Completed Task sequence_number=19659 in 0.0001390039687976241s", "level": "info", "logger": "boilermaker.app", "timestamp": "2024/12/10 15:52:24"}
+// Sad path test ->
+{"event": "[callback_task_test] Begin Task sequence_number=19661", "level": "info", "logger": "boilermaker.app", "timestamp": "2024/12/10 15:52:27"}
+{"event": "Failed processing task sequence_number=19661  Traceback (most recent call last):\n  File \"/app/.venv/lib/python3.12/site-packages/boilermaker/app.py\", line 238, in message_handler\n    result = await self.task_handler(task, sequence_number)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/.venv/lib/python3.12/site-packages/boilermaker/app.py\", line 306, in task_handler\n    result = await function(\n             ^^^^^^^^^^^^^^^\n  File \"/app/boilermaker_example.py\", line 210, in callback_task_test\n    raise ValueError(\"Negative numbers are a bummer\")\nValueError: Negative numbers are a bummer\n", "level": "error", "logger": "boilermaker.app", "timestamp": "2024/12/10 15:52:27"}
+{"event": "[sad_path] Begin Task sequence_number=19663", "level": "info", "logger": "boilermaker.app", "timestamp": "2024/12/10 15:52:28"}
+{"event": "[sad_path] Completed Task sequence_number=19663 in 0.00020030408632010221s", "level": "info", "logger": "boilermaker.app", "timestamp": "2024/12/10 15:52:28"}
+```
+
 
 ## FAQ
 

--- a/boilermaker/app.py
+++ b/boilermaker/app.py
@@ -244,7 +244,8 @@ class Boilermaker:
                 await self.publish_task(task.on_success)
 
         except RetryException as retry:
-            # A retry has been requested
+            # A retry has been requested:
+            # no on_failure run until after retries exhausted
             delay = task.get_next_delay()
             warn_msg = (
                 "Event retry requested. Publishing retry:"

--- a/boilermaker/failure.py
+++ b/boilermaker/failure.py
@@ -1,0 +1,24 @@
+from typing import TypeAlias
+
+
+# Singleton Failure: we'll create one specific instance to represent a failure
+# and check identity to see if it's been returned.
+# Do not use this class directly, use `TaskFailureResult` for a value of type `TaskFailureResultType`.
+class _TaskFailureResult:
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            # Put any initialization here.
+        return cls._instance
+
+    def __call__(self):
+        return self
+
+# This is the Singleton instance of TaskFailureResult.
+# Tasks can *return* this value to signal a failure.
+# This is a singleton, so we can check for identity.
+TaskFailureResult = _TaskFailureResult()
+TaskFailureResultType: TypeAlias = _TaskFailureResult
+

--- a/boilermaker/service_bus.py
+++ b/boilermaker/service_bus.py
@@ -30,7 +30,6 @@ class AzureServiceBus:
             raise ValueError("Invalid configuration for AzureServiceBus")
         return None
 
-
     @property
     def client(self):
         if self._client is None:

--- a/boilermaker/task.py
+++ b/boilermaker/task.py
@@ -44,9 +44,6 @@ class Task(BaseModel):
             **kwargs,
         )
 
-    def __bool__(self) -> bool:
-        return self.can_retry
-
     @property
     def acks_early(self):
         return not self.acks_late

--- a/boilermaker/task.py
+++ b/boilermaker/task.py
@@ -44,6 +44,9 @@ class Task(BaseModel):
             **kwargs,
         )
 
+    def __bool__(self) -> bool:
+        return self.can_retry
+
     @property
     def acks_early(self):
         return not self.acks_late

--- a/boilermaker/task.py
+++ b/boilermaker/task.py
@@ -23,6 +23,10 @@ class Task(BaseModel):
     # opentelemetry parent trace id is included here
     diagnostic_id: str | None
 
+    # Callbacks for success and failure
+    on_success: typing.Optional["Task"] = None
+    on_failure: typing.Optional["Task"] = None
+
     @classmethod
     def default(cls, function_name: str, **kwargs):
         attempts = retries.RetryAttempts(
@@ -30,7 +34,7 @@ class Task(BaseModel):
         )
         policy = retries.RetryPolicy.default()
         if "policy" in kwargs:
-            policy = kwargs["policy"]
+            policy = kwargs.pop("policy")
         return cls(
             attempts=attempts,
             function_name=function_name,

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,16 +1,19 @@
 import asyncio
 import os
 
-from azure.identity.aio import DefaultAzureCredential
-from azure.servicebus.aio import ServiceBusSender
-
-from boilermaker.app import Boilermaker
 from boilermaker import retries
+from boilermaker.app import Boilermaker
+from boilermaker.config import Config
+from boilermaker.service_bus import AzureServiceBus
 
-
-azure_identity_async_credential = DefaultAzureCredential()
 service_bus_namespace_url = os.environ["SERVICE_BUS_NAMESPACE_URL"]
 service_bus_queue_name = os.environ["SERVICE_BUS_QUEUE_NAME"]
+conf = Config(
+    service_bus_namespace_url=service_bus_namespace_url,
+    service_bus_queue_name=service_bus_queue_name,
+)
+# We create a service bus Sender client
+service_bus_client = AzureServiceBus(conf)
 
 # This represents our "App" object
 class App:
@@ -26,13 +29,6 @@ async def background_task1(state, somearg, somekwarg=True):
     print(somearg)
     print(somekwarg)
 
-
-# We create a service bus Sender client
-service_bus_client = ServiceBusSender(
-    service_bus_namespace_url,
-    azure_identity_async_credential,
-    queue_name=service_bus_queue_name,
-)
 
 # Next we'll create a worker and register our task
 worker = Boilermaker(App({"key": "value"}), service_bus_client=service_bus_client)

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,0 +1,49 @@
+import asyncio
+import os
+
+from azure.identity.aio import DefaultAzureCredential
+from azure.servicebus.aio import ServiceBusSender
+
+from boilermaker.app import Boilermaker
+from boilermaker import retries
+
+
+azure_identity_async_credential = DefaultAzureCredential()
+service_bus_namespace_url = os.environ["SERVICE_BUS_NAMESPACE_URL"]
+service_bus_queue_name = os.environ["SERVICE_BUS_QUEUE_NAME"]
+
+# This represents our "App" object
+class App:
+    def __init__(self, data):
+        self.data = data
+
+
+# This is a background task that we'll register
+async def background_task1(state, somearg, somekwarg=True):
+    """`state` must be first argument."""
+    await state.data.get("key")
+    print(state)
+    print(somearg)
+    print(somekwarg)
+
+
+# We create a service bus Sender client
+service_bus_client = ServiceBusSender(
+    service_bus_namespace_url,
+    azure_identity_async_credential,
+    queue_name=service_bus_queue_name,
+)
+
+# Next we'll create a worker and register our task
+worker = Boilermaker(App({"key": "value"}), service_bus_client=service_bus_client)
+worker.register_async(background_task1, policy=retries.RetryPolicy.default())
+
+
+# Finally, this will schedule the task
+async def publish_task():
+    await worker.apply_async(
+        background_task1, "first-arg", somekwarg=False
+    )
+
+if __name__ == "__main__":
+    asyncio.run(publish_task())

--- a/examples/callbacks.py
+++ b/examples/callbacks.py
@@ -1,15 +1,20 @@
 import asyncio
 import os
 
-from azure.identity.aio import DefaultAzureCredential
-from azure.servicebus.aio import ServiceBusSender
 from boilermaker import retries
 from boilermaker.app import Boilermaker
+from boilermaker.config import Config
 from boilermaker.failure import TaskFailureResult
+from boilermaker.service_bus import AzureServiceBus
 
-azure_identity_async_credential = DefaultAzureCredential()
 service_bus_namespace_url = os.environ["SERVICE_BUS_NAMESPACE_URL"]
 service_bus_queue_name = os.environ["SERVICE_BUS_QUEUE_NAME"]
+conf = Config(
+    service_bus_namespace_url=service_bus_namespace_url,
+    service_bus_queue_name=service_bus_queue_name,
+)
+# We create a service bus Sender client
+service_bus_client = AzureServiceBus(conf)
 
 
 # This represents our "App" object
@@ -34,13 +39,6 @@ async def happy_path(state):
 async def sad_path(state):
     print("Everything is sad")
 
-
-# We create a service bus Sender client
-service_bus_client = ServiceBusSender(
-    service_bus_namespace_url,
-    azure_identity_async_credential,
-    queue_name=service_bus_queue_name,
-)
 
 # Next we'll create a worker and register our task
 worker = Boilermaker(App({"key": "value"}), service_bus_client=service_bus_client)

--- a/examples/callbacks.py
+++ b/examples/callbacks.py
@@ -1,0 +1,73 @@
+import asyncio
+import os
+
+from azure.identity.aio import DefaultAzureCredential
+from azure.servicebus.aio import ServiceBusSender
+
+from boilermaker.app import Boilermaker
+from boilermaker import retries
+
+
+azure_identity_async_credential = DefaultAzureCredential()
+service_bus_namespace_url = os.environ["SERVICE_BUS_NAMESPACE_URL"]
+service_bus_queue_name = os.environ["SERVICE_BUS_QUEUE_NAME"]
+
+
+# This represents our "App" object
+class App:
+    def __init__(self, data):
+        self.data = data
+
+
+async def a_background_task(state, param: int):
+    if param > 0:
+        print("Things seem to be going really well")
+        return None
+    raise ValueError("Negative numbers are a bummer")
+
+
+async def happy_path(state):
+    print("Everything is great!")
+
+
+async def sad_path(state):
+    print("Everything is sad")
+
+
+# We create a service bus Sender client
+service_bus_client = ServiceBusSender(
+    service_bus_namespace_url,
+    azure_identity_async_credential,
+    queue_name=service_bus_queue_name,
+)
+
+# Next we'll create a worker and register our task
+worker = Boilermaker(App({"key": "value"}), service_bus_client=service_bus_client)
+
+# We need to be sure our tasks are registered
+worker.register_async(a_background_task, policy=retries.NoRetry)
+worker.register_async(happy_path, policy=retries.NoRetry)
+worker.register_async(sad_path, policy=retries.NoRetry)
+
+# Now we can create a happy task and add callbacks
+happy_task = worker.create_task(a_background_task, 11)
+# This callback should get scheduled
+happy_task.on_success = worker.create_task(happy_path)
+# This callback will not
+happy_task.on_failure = worker.create_task(sad_path)
+
+# For good measure, we'll create a sad task too
+sad_task = worker.create_task(a_background_task, -20)
+# This callback should not get scheduled
+sad_task.on_success = worker.create_task(happy_path)
+# This callback should get scheduled
+sad_task.on_failure = worker.create_task(sad_path)
+
+# Finally, this will schedule the tasks
+async def publish_task():
+    await worker.publish_task(happy_task)
+    await worker.publish_task(sad_task)
+
+
+if __name__ == "__main__":
+    asyncio.run(publish_task())

--- a/examples/callbacks.py
+++ b/examples/callbacks.py
@@ -24,7 +24,7 @@ async def a_background_task(state, param: str):
         return None
     elif param == "fail":
         return TaskFailureResult
-    raise ValueError("Negative numbers are a bummer")
+    raise ValueError("Exceptions are a bummer!")
 
 
 async def happy_path(state):

--- a/examples/callbacks.py
+++ b/examples/callbacks.py
@@ -45,9 +45,9 @@ service_bus_client = ServiceBusSender(
 worker = Boilermaker(App({"key": "value"}), service_bus_client=service_bus_client)
 
 # We need to be sure our tasks are registered
-worker.register_async(a_background_task, policy=retries.NoRetry)
-worker.register_async(happy_path, policy=retries.NoRetry)
-worker.register_async(sad_path, policy=retries.NoRetry)
+worker.register_async(a_background_task, policy=retries.NoRetry())
+worker.register_async(happy_path, policy=retries.NoRetry())
+worker.register_async(sad_path, policy=retries.NoRetry())
 
 # Now we can create a happy task and add callbacks
 happy_task = worker.create_task(a_background_task, 11)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boilermaker-servicebus"
-version = "0.4.0"
+version = "0.5.0a1"
 description = "An async python Background task system using Azure Service Bus Queues"
 authors = [
     { "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" },

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,7 +1,6 @@
 import pytest
-
-from boilermaker.app import Boilermaker
 from boilermaker import retries
+from boilermaker.app import Boilermaker
 
 
 class State:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,11 @@
+import json
+import random
+
 import pytest
-from boilermaker import retries
+from azure.servicebus import ServiceBusReceivedMessage
+from azure.servicebus._common.constants import SEQUENCENUBMERNAME
+from azure.servicebus._pyamqp.message import Message
+from boilermaker import failure, retries
 from boilermaker.app import Boilermaker
 
 
@@ -14,11 +20,9 @@ DEFAULT_STATE = State({"somekey": "somevalue"})
 
 
 
-
 @pytest.fixture
 def app(sbus):
     return Boilermaker(DEFAULT_STATE, sbus)
-
 
 
 def test_app_state(app):
@@ -74,3 +78,326 @@ async def test_create_task(app):
     assert task.get_next_delay() == retries.RetryPolicy.default().delay
     assert task.record_attempt()
     assert task.attempts.attempts == 1
+
+
+def make_message(task, sequence_number: int = 123):
+    # Example taken from:
+    # azure-sdk-for-python/blob/main/sdk/servicebus/azure-servicebus/tests/test_message.py#L233
+    my_frame = [0, 0, 0]
+    amqp_received_message = Message(
+        data=[task.model_dump_json().encode("utf-8")],
+        message_annotations={SEQUENCENUBMERNAME: sequence_number},
+    )
+    return ServiceBusReceivedMessage(amqp_received_message, receiver=None, frame=my_frame)
+
+
+async def test_task_garbage_message(app, mockservicebus):
+    message_num = random.randint(100, 1000)
+    # We are going to make a custom, totally garbage message
+    my_frame = [0, 0, 0]
+    amqp_received_message = Message(
+        data=[b"{{\\]]))"], # Invalid JSON
+        message_annotations={SEQUENCENUBMERNAME: message_num},
+    )
+    msg = ServiceBusReceivedMessage(amqp_received_message, receiver=None, frame=my_frame)
+
+    # Now we can run the task
+    result = await app.message_handler(
+        msg, mockservicebus.get_queue_receiver()
+    )
+    assert result is None
+    # Task should *always* be settled
+    assert len(mockservicebus._receiver.method_calls) == 1
+    complete_msg_call = mockservicebus._receiver.method_calls[0]
+    assert complete_msg_call[1][0].sequence_number == message_num
+    # Should never publish
+    assert len(mockservicebus._sender.method_calls) == 0
+
+
+@pytest.mark.parametrize("acks_late", [True, False])
+@pytest.mark.parametrize("has_on_success", [True, False])
+async def test_task_success(has_on_success, acks_late, app, mockservicebus):
+    async def oktask(state):
+        return "OK"
+
+    async def onsuccess(state, **kwargs):
+        return 1
+
+    # Function must be registered first
+    app.register_async(oktask, policy=retries.RetryPolicy.default())
+    app.register_async(onsuccess, policy=retries.NoRetry())
+    # Now we can create a task out of it
+    task = app.create_task(oktask)
+    if has_on_success:
+        task.on_success = app.create_task(onsuccess, somekwarg="akwargval")
+    task.acks_late = acks_late
+
+    # Now we can run the task
+    message_num = random.randint(100, 1000)
+    result = await app.message_handler(
+        make_message(task, sequence_number=message_num), mockservicebus.get_queue_receiver()
+    )
+    assert result is None
+    # Task should *always* be settled
+    assert len(mockservicebus._receiver.method_calls) == 1
+    complete_msg_call = mockservicebus._receiver.method_calls[0]
+    assert complete_msg_call[1][0].sequence_number == message_num
+    if has_on_success:
+        # Publish new task with sender
+        assert len(mockservicebus._sender.method_calls) == 1
+        publish_success_call = mockservicebus._sender.method_calls[0]
+        assert publish_success_call[0] == "schedule_messages"
+        data = json.loads(str(publish_success_call[1][0]))
+        assert data["payload"]["args"] == []
+        assert data["payload"]["kwargs"] == {"somekwarg": "akwargval"}
+        assert data["function_name"] == "onsuccess"
+        assert data["on_success"] is None
+        assert data["on_failure"] is None
+    else:
+        # No new tasks published
+        assert not mockservicebus._sender.method_calls
+
+
+@pytest.mark.parametrize("acks_late", [True, False])
+@pytest.mark.parametrize("should_deadletter", [True, False])
+@pytest.mark.parametrize("has_on_failure", [True, False])
+async def test_task_failure(has_on_failure, should_deadletter, acks_late, app, mockservicebus):
+    async def failtask(state, **kwargs):
+        return failure.TaskFailureResult
+
+    async def onfail(state, **kwargs):
+        return 1
+
+    # Function must be registered first -> this function has a retry policy: it should never be retried
+    app.register_async(failtask, policy=retries.RetryPolicy.default())
+    app.register_async(onfail, policy=retries.NoRetry())
+    # Now we can create a task out of it
+    task = app.create_task(failtask)
+    task.acks_late = acks_late
+    task.should_dead_letter = should_deadletter
+    if has_on_failure:
+        # Set a failure task
+        task.on_failure = app.create_task(onfail, somekwarg="akwargval")
+
+    # Now we can run the task
+    message_num = random.randint(100, 1000)
+    result = await app.message_handler(
+        make_message(task, sequence_number=message_num), mockservicebus.get_queue_receiver()
+    )
+
+    # Task should *always* be settled
+    assert len(mockservicebus._receiver.method_calls) == 1
+    complete_msg_call = mockservicebus._receiver.method_calls[0]
+    assert complete_msg_call[1][0].sequence_number == message_num
+    if has_on_failure:
+        # Publish new task with sender
+        assert len(mockservicebus._sender.method_calls) == 1
+        publish_fail_call = mockservicebus._sender.method_calls[0]
+        assert publish_fail_call[0] == "schedule_messages"
+        data = json.loads(str(publish_fail_call[1][0]))
+        assert data["payload"]["args"] == []
+        assert data["payload"]["kwargs"] == {"somekwarg": "akwargval"}
+        assert data["function_name"] == "onfail"
+        assert data["on_success"] is None
+        assert data["on_failure"] is None
+    else:
+        # No new tasks published
+        assert not mockservicebus._sender.method_calls
+
+    if should_deadletter and acks_late:
+        assert complete_msg_call[0] == "dead_letter_message"
+    elif not acks_late:
+        assert complete_msg_call[0] == "complete_message"
+        assert complete_msg_call[1][0].sequence_number == message_num
+    assert result is None
+
+
+@pytest.mark.parametrize("should_deadletter", [True, False])
+@pytest.mark.parametrize("has_on_failure", [True, False])
+@pytest.mark.parametrize("can_retry", [True, False])
+async def test_task_retries_with_onfail(can_retry, has_on_failure, should_deadletter, app, mockservicebus):
+    async def retrytask(state):
+        raise retries.RetryException("Retry me", policy=retries.RetryPolicy.default())
+
+    async def onfail(state, **kwargs):
+        return 1
+
+    # Function must be registered first
+    app.register_async(retrytask, policy=retries.RetryPolicy.default())
+    app.register_async(onfail, policy=retries.NoRetry())
+    # Now we can create a task out of it
+    task = app.create_task(retrytask)
+    task.should_dead_letter = should_deadletter
+    if has_on_failure:
+        # Set a failure task
+        task.on_failure = app.create_task(onfail, somekwarg="akwargval")
+
+    if not can_retry:
+        task.attempts.attempts = task.policy.max_tries + 1
+
+    # Now we can run the task
+    message_num = random.randint(100, 1000)
+    result = await app.message_handler(
+        make_message(task, sequence_number=message_num), mockservicebus.get_queue_receiver()
+    )
+
+    # Task should *always* be settled
+    assert len(mockservicebus._receiver.method_calls) == 1
+    complete_msg_call = mockservicebus._receiver.method_calls[0]
+    assert complete_msg_call[1][0].sequence_number == message_num
+
+    if has_on_failure and not can_retry:
+        # Publish onfail task with sender
+        assert len(mockservicebus._sender.method_calls) == 1
+        publish_fail_call = mockservicebus._sender.method_calls[0]
+        assert publish_fail_call[0] == "schedule_messages"
+        data = json.loads(str(publish_fail_call[1][0]))
+        assert data["payload"]["args"] == []
+        assert data["payload"]["kwargs"] == {"somekwarg": "akwargval"}
+        assert data["function_name"] == "onfail"
+        assert data["on_success"] is None
+        assert data["on_failure"] is None
+    elif not has_on_failure and can_retry:
+        # Publish retry task with sender
+        assert len(mockservicebus._sender.method_calls) == 1
+        publish_fail_call = mockservicebus._sender.method_calls[0]
+        assert publish_fail_call[0] == "schedule_messages"
+        data = json.loads(str(publish_fail_call[1][0]))
+        assert data["payload"]["args"] == []
+        assert data["payload"]["kwargs"] == {}
+        assert data["function_name"] == "retrytask"
+        assert data["on_success"] is None
+        assert data["on_failure"] is None
+    elif has_on_failure and can_retry:
+        # Publish retry task with onfail task
+        assert len(mockservicebus._sender.method_calls) == 1
+        publish_fail_call = mockservicebus._sender.method_calls[0]
+        assert publish_fail_call[0] == "schedule_messages"
+        data = json.loads(str(publish_fail_call[1][0]))
+        assert data["payload"]["args"] == []
+        assert data["payload"]["kwargs"] == {}
+        assert data["function_name"] == "retrytask"
+        assert data["on_success"] is None
+        assert data["on_failure"] is not None
+        assert data["on_failure"]["function_name"] == "onfail"
+    else:
+        # No new tasks published
+        assert not mockservicebus._sender.method_calls
+
+    if should_deadletter and not can_retry:
+        assert complete_msg_call[0] == "dead_letter_message"
+    elif not can_retry:
+        assert complete_msg_call[0] == "complete_message"
+        assert complete_msg_call[1][0].sequence_number == message_num
+    assert result is None
+
+
+@pytest.mark.parametrize("acks_late", [True, False])
+@pytest.mark.parametrize("should_deadletter", [True, False])
+@pytest.mark.parametrize("can_retry", [True, False])
+async def test_task_retries_acks_late(can_retry, should_deadletter, acks_late, app, mockservicebus):
+    async def retrytask(state):
+        raise retries.RetryException("Retry me", policy=retries.RetryPolicy.default())
+
+    # Function must be registered first
+    app.register_async(retrytask, policy=retries.RetryPolicy.default())
+    # Now we can create a task out of it
+    task = app.create_task(retrytask)
+    task.acks_late = acks_late
+    task.should_dead_letter = should_deadletter
+    if not can_retry:
+        # Make it fail early
+        task.attempts.attempts = task.policy.max_tries + 1
+
+    # Now we can run the task
+    message_num = random.randint(100, 1000)
+    result = await app.message_handler(
+        make_message(task, sequence_number=message_num), mockservicebus.get_queue_receiver()
+    )
+
+    # Task should *always* be settled
+    assert len(mockservicebus._receiver.method_calls) == 1
+    complete_msg_call = mockservicebus._receiver.method_calls[0]
+    assert complete_msg_call[1][0].sequence_number == message_num
+    if should_deadletter and not acks_late and not can_retry:
+        # We should have received the message again
+        assert len(mockservicebus._sender.method_calls) == 0
+        # acks_early => complete_message (before deadletter)
+        assert complete_msg_call[0] == "complete_message"
+    elif should_deadletter and acks_late and not can_retry:
+        # Publish onfail task with sender
+        assert len(mockservicebus._sender.method_calls) == 0
+        assert complete_msg_call[0] == "dead_letter_message"
+    elif can_retry:
+        # Publish retry task with onfail task
+        assert len(mockservicebus._sender.method_calls) == 1
+        publish_call = mockservicebus._sender.method_calls[0]
+        assert publish_call[0] == "schedule_messages"
+        data = json.loads(str(publish_call[1][0]))
+        assert data["payload"]["args"] == []
+        assert data["payload"]["kwargs"] == {}
+        assert data["function_name"] == "retrytask"
+        assert data["on_success"] is None
+        assert data["on_failure"] is None
+    else:
+        # No new tasks published
+        assert not mockservicebus._sender.method_calls
+
+    assert result is None
+
+
+@pytest.mark.parametrize("acks_late", [True, False])
+@pytest.mark.parametrize("should_deadletter", [True, False])
+@pytest.mark.parametrize("has_on_failure", [True, False])
+async def test_task_handle_exception(has_on_failure, should_deadletter, acks_late, app, mockservicebus):
+    async def except_task(state):
+        raise FloatingPointError("Some weird error happened")
+
+    async def onfail(state, **kwargs):
+        return 1
+
+    # Function must be registered first
+    app.register_async(except_task, policy=retries.RetryPolicy.default())
+    app.register_async(onfail, policy=retries.NoRetry())
+    # Now we can create a task out of it
+    task = app.create_task(except_task)
+    task.acks_late = acks_late
+    task.should_dead_letter = should_deadletter
+
+    if has_on_failure:
+        # Set a failure task
+        task.on_failure = app.create_task(onfail, somekwarg="akwargval")
+
+    # Now we can run the task
+    message_num = random.randint(100, 1000)
+    result = await app.message_handler(
+        make_message(task, sequence_number=message_num), mockservicebus.get_queue_receiver()
+    )
+
+    # Task should *always* be settled
+    assert len(mockservicebus._receiver.method_calls) == 1
+    complete_msg_call = mockservicebus._receiver.method_calls[0]
+    assert complete_msg_call[1][0].sequence_number == message_num
+    if not has_on_failure:
+        assert len(mockservicebus._sender.method_calls) == 0
+        if should_deadletter and not acks_late:
+            # We should have received the message again
+            # acks_early => complete_message (before deadletter)
+            assert complete_msg_call[0] == "complete_message"
+        elif should_deadletter and acks_late:
+            # Publish onfail task with sender
+            assert len(mockservicebus._sender.method_calls) == 0
+            assert complete_msg_call[0] == "dead_letter_message"
+    else:
+        # Publish retry task with onfail task
+        assert len(mockservicebus._sender.method_calls) == 1
+        publish_call = mockservicebus._sender.method_calls[0]
+        assert publish_call[0] == "schedule_messages"
+        data = json.loads(str(publish_call[1][0]))
+        assert data["payload"]["args"] == []
+        assert data["payload"]["kwargs"] == {'somekwarg': 'akwargval'}
+        assert data["function_name"] == "onfail"
+        assert data["on_success"] is None
+        assert data["on_failure"] is None
+
+    assert result is None

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,77 @@
+import pytest
+
+from boilermaker.app import Boilermaker
+from boilermaker import retries
+
+
+class State:
+    def __init__(self, inner):
+        self.inner = inner
+
+    def __getitem__(self, key):
+        return self.inner[key]
+
+DEFAULT_STATE = State({"somekey": "somevalue"})
+
+
+
+
+@pytest.fixture
+def app(sbus):
+    return Boilermaker(DEFAULT_STATE, sbus)
+
+
+
+def test_app_state(app):
+    assert app.state == DEFAULT_STATE
+
+
+async def test_task_decorator(app):
+    @app.task()
+    async def somefunc(state):
+        return state["somekey"]
+
+    assert somefunc.__name__ in app.task_registry
+    assert app.task_registry[somefunc.__name__].function_name == somefunc.__name__
+
+    assert await somefunc(DEFAULT_STATE) == "somevalue"
+
+
+async def test_task_decorator_with_policy(app):
+    @app.task(policy=retries.RetryPolicy.default())
+    async def somefunc(state):
+        return state["somekey"]
+
+    assert somefunc.__name__ in app.task_registry
+    assert app.task_registry[somefunc.__name__].function_name == somefunc.__name__
+    assert app.task_registry[somefunc.__name__].policy == retries.RetryPolicy.default()
+    assert await somefunc(DEFAULT_STATE) == "somevalue"
+
+
+async def test_app_register_async(app):
+    async def somefunc(state):
+        return state["somekey"]
+
+    app.register_async(somefunc, policy=retries.RetryPolicy.default())
+    assert somefunc.__name__ in app.task_registry
+    assert app.task_registry[somefunc.__name__].function_name == somefunc.__name__
+    assert await somefunc(DEFAULT_STATE) == "somevalue"
+
+async def test_create_task(app):
+    async def somefunc(state, **kwargs):
+        state.inner.update(kwargs)
+        return state["somekey"]
+
+    # Function must be registered  first
+    app.register_async(somefunc, policy=retries.RetryPolicy.default())
+    # Now we can create a task out of it
+    task = app.create_task(somefunc, somekwarg="akwargval")
+    assert task.function_name == "somefunc"
+    assert task.payload == {"args": (), "kwargs": {"somekwarg": "akwargval"}}
+    assert task.attempts.attempts == 0
+    assert task.acks_late
+    assert task.acks_early is False
+    assert task.can_retry
+    assert task.get_next_delay() == retries.RetryPolicy.default().delay
+    assert task.record_attempt()
+    assert task.attempts.attempts == 1

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -11,3 +11,14 @@ def test_can_retry():
     # can no longer retry
     atask.record_attempt()
     assert not atask.can_retry
+
+
+def test_get_next_delay():
+    atask = task.Task.default("somefunc")
+    first_delay = atask.get_next_delay()
+    atask.record_attempt()
+    second_delay = atask.get_next_delay()
+
+    assert first_delay <= atask.policy.delay_max
+    assert second_delay <= atask.policy.delay_max
+    assert second_delay >= first_delay

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "boilermaker-servicebus"
-version = "0.4.0"
+version = "0.5.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
This PR adds the ability to:
- Create a `Task` from a partially applied function
- Assign another Task to the `on_success` or `on_failure` attributes
- The Boilermaker app will run the callback on success or failure (exception or retries exhausted)
- Add a singleton `TaskFailureResult` instance which any handler can return to indicate failure.

This PR also adds some tests for the `Boilermaker` application object. It's an oversight that they've been missing so far.

Lastly, we will update the README with an example of creating a task and setting up callbacks.

For a future PR, we can look to adding something like celery's `chain` to build up a pipeline of tasks. Ideally, this would be something like a DAG that's easy to create and think about (but as a recursive data structure where the whole DAG is a Task and each node in the DAG is a task).

In addition, it would be useful to feed the return value of one handler into the callback as arguments (and if an exception into the failure handler). It's not obvious how to do this in an extremely simple way.

## Examples

```python

# Now we can create a happy task and add callbacks
happy_task = worker.create_task(a_background_task, 11)
# This callback should get scheduled
happy_task.on_success = worker.create_task(happy_path)
# This callback will not
happy_task.on_failure = worker.create_task(sad_path)

# For good measure, we'll create a sad task too
sad_task = worker.create_task(a_background_task, -20)
# This callback should not get scheduled
sad_task.on_success = worker.create_task(happy_path)
# This callback should get scheduled
sad_task.on_failure = worker.create_task(sad_path)

# Finally, this will schedule the tasks
async def publish_task():
    await worker.publish_task(happy_task)
    await worker.publish_task(sad_task)

```

## Additional Changes

This PR also greatly increases test-coverage to 85%, including coverage of the `app.py` module, which had _no_ coverage previously.