### PR TITLE
Overhauling retry machinery

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ __Note__: `on_failure` callbacks will only be run __after all retries have been 
 There are three places where retries for a task can be configured:
 
 - When initially registering a task (the task default).
-- When scheduling a task (override the default).
-- When raising a `RetryException` in order to trigger a retry (also overrides the default).
+- When scheduling a task (overrides the default for that invocation).
+- When raising a `RetryException` with a custom policy (overrides default _if_ different).
 
 Examples of each are included below.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ async def background_task1(state, somearg, somekwarg=True):
 # Our task must be registered to be invocable.
 boilermaker_app.register_async(background_task1, policy=...A retry policy goes here...)
 ```
-**Note**: `Boilermaker` does not currently have a way to store or use the results of tasks, and all arguments must be JSON-serializable.
+__Note__: `Boilermaker` does not currently have a way to store or use the results of tasks, and all arguments must be JSON-serializable.
 
 ### Complete Example
 
@@ -84,7 +84,7 @@ if __name__ == "__main__":
     asyncio.run(publish_task())
 ```
 
-In another process, we'll need to *run* a background task worker. That looks like this:
+In another process, we'll need to _run_ a background task worker. That looks like this:
 
 ```python
 async def run_worker():
@@ -101,7 +101,7 @@ If we look in the logs for our other process, we should be able to see this task
 ```
 
 
-## Callbacks and Retries
+## Callbacks
 
 It is possible to register callbacks for tasks, which can run on success or failure. To schedule a task with callbacks, we have to create a task object and then set a success and/or failure callback. Finally, instead of `apply_async` we have to call `publish_task`:
 
@@ -128,7 +128,7 @@ async def sad_path(state):
 
 
 # We need to be sure our tasks are registered
-worker.register_async(a_background_task, policy=retries.NoRetry)
+worker.register_async(a_background_task, policy=retries.NoRetry())
 worker.register_async(happy_path, policy=retries.NoRetry())
 worker.register_async(sad_path, policy=retries.NoRetry())
 
@@ -171,6 +171,121 @@ Here are examples of log out from running the above:
 {"event": "Failed processing task sequence_number=19661  Traceback (most recent call last):\n  File \"/app/.venv/lib/python3.12/site-packages/boilermaker/app.py\", line 238, in message_handler\n    result = await self.task_handler(task, sequence_number)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/.venv/lib/python3.12/site-packages/boilermaker/app.py\", line 306, in task_handler\n    result = await function(\n             ^^^^^^^^^^^^^^^\n  File \"/app/boilermaker_example.py\", line 210, in callback_task_test\n    raise ValueError(\"Negative numbers are a bummer\")\nValueError: Negative numbers are a bummer\n", "level": "error", "logger": "boilermaker.app", "timestamp": "2024/12/10 15:52:27"}
 {"event": "[sad_path] Begin Task sequence_number=19663", "level": "info", "logger": "boilermaker.app", "timestamp": "2024/12/10 15:52:28"}
 {"event": "[sad_path] Completed Task sequence_number=19663 in 0.00020030408632010221s", "level": "info", "logger": "boilermaker.app", "timestamp": "2024/12/10 15:52:28"}
+```
+
+## Retries
+
+Retries are configured in `Boilermaker` using a `RetryPolicy`:
+
+```python
+class RetryPolicy(BaseModel):
+    # Capped at this value
+    max_tries: int = MAX_REASONABLE_RETRIES
+    # Seconds
+    delay: int = 0
+    # Max seconds
+    delay_max: int = MAX_BACKOFF_SECONDS
+    # Mode for retrying
+    retry_mode: RetryMode = RetryMode.Fixed
+```
+
+Retries are __scheduled__ only by raising a `RetryException`:
+
+```python
+def sometask(state):
+    raise RetryException("Please try again!")
+```
+
+__Note__: _all_ tasks __must__ be registered with a `RetryPolicy`, but `Boilermaker` will only retry tasks that have raised a `RetryException`.
+
+If you do not want your tasks to be retried:
+
+- Do not throw a `RetryException` from inside of your task.
+- Register them with a `NoRetry` policy: `worker.register_async(..., policy=retries.NoRetry())`
+
+`NoRetry()` is simply a special policy where `max_tries=1`.
+
+__Note__: `on_failure` callbacks will only be run __after all retries have been exhausted__.
+
+### Scheduling Retries
+
+There are three places where retries for a task can be configured:
+
+- When initially registering a task (the task default).
+- When scheduling a task (override the default).
+- When raising a `RetryException` in order to trigger a retry (also overrides the default).
+
+Examples of each are included below.
+
+#### Register Task with a Default Retry Policy
+
+When a task has been registered, we can set a retry policy for any invocation of it:
+
+```python
+from boilermaker import retries
+
+async def a_background_task(state, param: str):
+    if param == "throwing":
+        # This will retry using the *default policy* set when the task was registered
+        raise retries.RetryException("We are thrown")
+    return "OK"
+
+worker.register_async(a_background_task, policy=retries.RetryPolicy.default())
+```
+
+This example works like a template for running the task. If `a_background_task` gets retried, `Boilermaker` will use the default policy to calculate its next delay and max attempts allowed.
+
+#### Scheduling a Task with a Different Retry Policy
+
+Sometimes we'd like to publish our task so that its retries follow a different plan than the task was originally registered with.
+
+We can __publish__ (schedule) a particular task with a different retry policy like this:
+
+```python
+from boilermaker import retries
+
+async def a_background_task(state, param: str):
+    if param == "throwing":
+        # This will retry using the set when *scheduling* the task (see below)
+        raise retries.RetryException("We are thrown")
+    return "OK"
+
+# First we register the task
+worker.register_async(a_background_task, policy=retries.RetryPolicy.default())
+
+async def schedule_task_with_different_policy():
+    new_policy=retries.RetryPolicy(
+        max_tries=100, delay=2, delay_max=1000, retry_mode=retries.RetryMode.Exponential,
+    )
+    await worker.apply_async(a_background_task, "throwing", policy=new_policy)
+```
+
+In the above example, _this_ invocation of the task has a new retry policy, but all other invocations of this task elsewhere in our codebase will continue to use the default.
+
+
+#### Raising a `RetryException` with a Different Policy
+
+Lastly, it's also possible to request a different `RetryPolicy` from _inside_ a task:
+
+
+```python
+from boilermaker import retries
+
+async def a_background_task(state, param: str):
+    if param == "throwing":
+        # This will retry using *THIS* RetryPolicy
+        raise retries.RetryExceptionDefaultExponential("We are thrown", max_tries=42)
+    return "OK"
+
+# First we register the task
+worker.register_async(a_background_task, policy=retries.RetryPolicy.default())
+
+async def schedule_task_with_different_policy():
+    new_policy=retries.RetryPolicy(
+        max_tries=10, delay=20, delay_max=100, retry_mode=retries.RetryMode.Linear,
+    )
+    # Because the task raises a different policy, this one will get dropped in face of `RetryExceptionDefaultExponential`
+    await worker.apply_async(a_background_task, "throwing", policy=new_policy)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,8 @@ from boilermaker import retries
 
 async def a_background_task(state, param: str):
     if param == "throwing":
-        # This will retry using the set when *scheduling* the task (see below)
+        # This will retry using the RetryPolicy set
+        # when *scheduling* the task (see below)
         raise retries.RetryException("We are thrown")
     return "OK"
 

--- a/boilermaker/app.py
+++ b/boilermaker/app.py
@@ -292,12 +292,10 @@ class Boilermaker:
 
             delay = task.get_next_delay()
             warn_msg = (
-                "Event retry requested. Publishing retry:"
-                f"[ {task.function_name=}"
-                f" {retry.msg=}"
-                f" {task.attempts.attempts=}"
-                f" {delay=}"
-                f" {sequence_number=} ]"
+                f"[{sequence_number=}] {retry.msg}. Publishing retry: "
+                f"<function={task.function_name}>, "
+                f" attempts={task.attempts.attempts}, "
+                f" {delay=}>"
             )
             logger.warning(warn_msg)
             await self.publish_task(

--- a/boilermaker/app.py
+++ b/boilermaker/app.py
@@ -2,6 +2,7 @@
 Async tasks received from Service Bus go in here
 
 """
+
 import copy
 import logging
 import signal
@@ -30,7 +31,7 @@ from pydantic import ValidationError
 
 from . import sample, tracing
 from .failure import TaskFailureResult, TaskFailureResultType
-from .retries import RetryException
+from .retries import NoRetry, RetryException, RetryPolicy
 from .task import Task
 
 tracer: trace.Tracer = trace.get_tracer(__name__)
@@ -96,7 +97,9 @@ class Boilermaker:
             self.register_async(fn, **options)
         return self
 
-    def create_task(self, fn, *args, **kwargs) -> Task:
+    def create_task(
+        self, fn, *args, policy: RetryPolicy | None = None, **kwargs
+    ) -> Task:
         """
         Create a Task object (but do not publish it).
         """
@@ -109,21 +112,38 @@ class Boilermaker:
         task_proto = self.task_registry[fn.__name__]
         task = copy.deepcopy(task_proto)
         task.payload = payload
+        if policy is not None:
+            task.policy = policy
+
         return task
 
-    async def apply_async(self, fn, *args, delay: int = 0, retries: int = 3, **kwargs):
+    async def apply_async(
+        self,
+        fn,
+        *args,
+        delay: int = 0,
+        publish_attempts: int = 3,
+        policy: RetryPolicy | None = None,
+        **kwargs,
+    ):
         """
         Wrap up this function call as a task and publish to broker.
         """
-        task = self.create_task(fn, *args, **kwargs)
-        return await self.publish_task(task, delay=delay, retries=retries)
+        task = self.create_task(fn, *args, policy=policy, **kwargs)
+        return await self.publish_task(
+            task, delay=delay, publish_attempts=publish_attempts
+        )
 
     @tracer.start_as_current_span("publish-task")
-    async def publish_task(self, task: Task, delay: int = 0, retries: int = 3):
+    async def publish_task(
+        self,
+        task: Task,
+        delay: int = 0,
+        publish_attempts: int = 3,
+    ):
         """Turn the task into JSON and publish to Service Bus"""
         encountered_errors = []
-
-        for _i in range(0, retries):
+        for _i in range(publish_attempts):
             try:
                 return await self.service_bus_client.send_message(
                     task.model_dump_json(),
@@ -134,8 +154,8 @@ class Boilermaker:
                 ServiceBusConnectionError,
                 ServiceBusAuthorizationError,
                 ServiceBusAuthenticationError,
-            ) as e:
-                encountered_errors.append(e)
+            ) as exc:
+                encountered_errors.append(exc)
         else:
             raise BoilermakerAppException(
                 "Error encountered while publishing task to service bus",
@@ -237,7 +257,7 @@ class Boilermaker:
                 await self.deadletter_or_complete_task(
                     receiver, msg, "ProcessingError", task, detail="Retries exhausted"
                 )
-            # This task is a failure because there it did not succeed and retries are exhausted
+            # This task is a failure because it did not succeed and retries are exhausted
             if task.on_failure is not None:
                 await self.publish_task(task.on_failure)
             # Early return here: no more processing
@@ -263,7 +283,14 @@ class Boilermaker:
                 await self.publish_task(task.on_success)
         except RetryException as retry:
             # A retry has been requested:
-            # no on_failure run until after retries exhausted
+            # Calculate next delay and publish retry.
+            # Do not run on_failure run until after retries exhausted!
+            # The `retry` RetryException may have a policy -> What if it's different from the Task?
+            if retry.policy and retry.policy != task.policy:
+                # This will publish the *next* instance of the task using *this* policy
+                task.policy = retry.policy
+                logger.warning(f"Task policy updated to retry policy {retry.policy}")
+
             delay = task.get_next_delay()
             warn_msg = (
                 "Event retry requested. Publishing retry:"

--- a/boilermaker/app.py
+++ b/boilermaker/app.py
@@ -121,7 +121,7 @@ class Boilermaker:
         fn,
         *args,
         delay: int = 0,
-        publish_attempts: int = 3,
+        publish_attempts: int = 1,
         policy: RetryPolicy | None = None,
         **kwargs,
     ):
@@ -138,7 +138,7 @@ class Boilermaker:
         self,
         task: Task,
         delay: int = 0,
-        publish_attempts: int = 3,
+        publish_attempts: int = 1,
     ):
         """Turn the task into JSON and publish to Service Bus"""
         encountered_errors = []

--- a/boilermaker/app.py
+++ b/boilermaker/app.py
@@ -292,10 +292,9 @@ class Boilermaker:
 
             delay = task.get_next_delay()
             warn_msg = (
-                f"{retry.msg}. "
-                f"Retrying... <function={task.function_name}, "
-                f" attempts={task.attempts.attempts}, "
-                f" {delay=}, {sequence_number=}>"
+                f"{retry.msg} "
+                f"[attempt {task.attempts.attempts} of {task.policy.max_tries}] "
+                f"Publishing retry... {sequence_number=} <function={task.function_name}> with {delay=} "
             )
             logger.warning(warn_msg)
             await self.publish_task(

--- a/boilermaker/app.py
+++ b/boilermaker/app.py
@@ -2,7 +2,6 @@
 Async tasks received from Service Bus go in here
 
 """
-
 import copy
 import logging
 import signal
@@ -31,7 +30,7 @@ from pydantic import ValidationError
 
 from . import sample, tracing
 from .failure import TaskFailureResult, TaskFailureResultType
-from .retries import NoRetry, RetryException, RetryPolicy
+from .retries import RetryException, RetryPolicy
 from .task import Task
 
 tracer: trace.Tracer = trace.get_tracer(__name__)

--- a/boilermaker/app.py
+++ b/boilermaker/app.py
@@ -292,10 +292,10 @@ class Boilermaker:
 
             delay = task.get_next_delay()
             warn_msg = (
-                f"[{sequence_number=}] {retry.msg}. Publishing retry: "
-                f"<function={task.function_name}>, "
+                f"{retry.msg}. "
+                f"Retrying... <function={task.function_name}, "
                 f" attempts={task.attempts.attempts}, "
-                f" {delay=}>"
+                f" {delay=}, {sequence_number=}>"
             )
             logger.warning(warn_msg)
             await self.publish_task(

--- a/boilermaker/retries.py
+++ b/boilermaker/retries.py
@@ -134,7 +134,7 @@ class RetryExceptionDefaultExponential(RetryException):
             "retry_mode": RetryMode.Exponential,
         }
         defaults.update(kwargs)
-        super().__init__(msg, policy=RetryPolicy(**defaults))
+        super().__init__(msg, policy=RetryPolicy.model_validate(defaults))
 
 
 class RetryExceptionDefaultLinear(RetryException):
@@ -146,4 +146,4 @@ class RetryExceptionDefaultLinear(RetryException):
             "retry_mode": RetryMode.Linear,
         }
         defaults.update(kwargs)
-        super().__init__(msg, policy=RetryPolicy(**defaults))
+        super().__init__(msg, policy=RetryPolicy.model_validate(defaults))

--- a/boilermaker/retries.py
+++ b/boilermaker/retries.py
@@ -4,6 +4,7 @@ import random
 
 from pydantic import BaseModel, field_validator
 
+DEFAULT_MAX_TRIES = 5
 MAX_REASONABLE_RETRIES = 100
 MAX_BACKOFF_SECONDS = 3600  # an hour
 
@@ -21,7 +22,7 @@ class RetryMode(enum.IntEnum):
 # Default RetryPolicy is try up to 5 times waiting 60s each time
 class RetryPolicy(BaseModel):
     # Capped at this value
-    max_tries: int = MAX_REASONABLE_RETRIES
+    max_tries: int = DEFAULT_MAX_TRIES
     # Seconds
     delay: int = 0
     # Max seconds

--- a/boilermaker/retries.py
+++ b/boilermaker/retries.py
@@ -4,7 +4,7 @@ import random
 
 from pydantic import BaseModel, field_validator
 
-MAX_REASONABLE_RETRIES = 30
+MAX_REASONABLE_RETRIES = 100
 MAX_BACKOFF_SECONDS = 3600  # an hour
 
 
@@ -29,6 +29,20 @@ class RetryPolicy(BaseModel):
     # Mode for retrying
     retry_mode: RetryMode = RetryMode.Fixed
 
+    def __str__(self):
+        return (
+            f"RetryPolicy(max_tries={self.max_tries}, delay={self.delay}, "
+            f"delay_max={self.delay_max}, retry_mode={self.retry_mode})"
+        )
+
+    def __eq__(self, other):
+        return (
+            self.max_tries == other.max_tries
+            and self.delay == other.delay
+            and self.delay_max == other.delay_max
+            and self.retry_mode == other.retry_mode
+        )
+
     @field_validator("delay")
     def delay_is_positive(cls, v):
         if v < 0:
@@ -52,6 +66,11 @@ class RetryPolicy(BaseModel):
         # Default is try up to 5 times waiting 60s each time
         return cls(max_tries=5, delay=120, delay_max=120, retry_mode=RetryMode.Fixed)
 
+    @classmethod
+    def no_retry(cls):
+        # max_tries=1 should disable retries. Duplicates NoRetry class below
+        return cls(max_tries=1, delay=5, delay_max=5, retry_mode=RetryMode.Fixed)
+
     def get_delay_interval(self, attempts_so_far: int) -> int:
         """Figure out how many seconds of delay to wait before next attempt"""
         match self.retry_mode:
@@ -73,6 +92,7 @@ class RetryPolicy(BaseModel):
 # NoRetry only tries one time
 class NoRetry(RetryPolicy):
     def __init__(self):
+        """Duplciates RetryPolicy.no_retry() constructor"""
         super().__init__(max_tries=1, delay=5, delay_max=5, retry_mode=RetryMode.Fixed)
 
 
@@ -95,27 +115,35 @@ class RetryAttempts(BaseModel):
 
 
 class RetryException(Exception):
-    def __init__(self, msg: str, policy: RetryPolicy):
+    def __init__(self, msg: str, policy: RetryPolicy | None = None):
         self.msg = msg
         self.policy = policy
 
 
 class RetryExceptionDefault(RetryException):
     def __init__(self, msg: str):
-        super().__init__(msg, RetryPolicy.default())
+        super().__init__(msg, policy=RetryPolicy.default())
 
 
 class RetryExceptionDefaultExponential(RetryException):
-    def __init__(self, msg: str):
-        policy = RetryPolicy(
-            max_tries=5, delay=30, delay_max=600, retry_mode=RetryMode.Exponential
-        )
-        super().__init__(msg, policy)
+    def __init__(self, msg: str, **kwargs):
+        defaults = {
+            "max_tries": 5,
+            "delay": 30,
+            "delay_max": 600,
+            "retry_mode": RetryMode.Exponential,
+        }
+        defaults.update(kwargs)
+        super().__init__(msg, policy=RetryPolicy(**defaults))
 
 
 class RetryExceptionDefaultLinear(RetryException):
-    def __init__(self, msg: str):
-        policy = RetryPolicy(
-            max_tries=5, delay=30, delay_max=600, retry_mode=RetryMode.Linear
-        )
-        super().__init__(msg, policy)
+    def __init__(self, msg: str, **kwargs):
+        defaults = {
+            "max_tries": 5,
+            "delay": 30,
+            "delay_max": 600,
+            "retry_mode": RetryMode.Linear,
+        }
+        defaults.update(kwargs)
+        super().__init__(msg, policy=RetryPolicy(**defaults))

--- a/boilermaker/retries.py
+++ b/boilermaker/retries.py
@@ -92,7 +92,7 @@ class RetryPolicy(BaseModel):
 # NoRetry only tries one time
 class NoRetry(RetryPolicy):
     def __init__(self):
-        """Duplciates RetryPolicy.no_retry() constructor"""
+        """Duplicates RetryPolicy.no_retry() constructor"""
         super().__init__(max_tries=1, delay=5, delay_max=5, retry_mode=RetryMode.Fixed)
 
 

--- a/boilermaker/sample.py
+++ b/boilermaker/sample.py
@@ -1,5 +1,6 @@
 import logging
 
+from .retries import RetryExceptionDefaultExponential
 from .task import Task
 
 logger = logging.getLogger(__name__)
@@ -16,3 +17,12 @@ async def debug_task(state):
 
 STATIC_DEBUG_TASK = Task.default(TASK_NAME, acks_late=False)
 STATIC_DEBUG_TASK.payload = {"args": [], "kwargs": {}}
+
+
+async def debug_task_retry_policy(state, max_tries=5, delay=30, delay_max=600):
+    """
+    This task does nothing
+    """
+    raise RetryExceptionDefaultExponential(
+        "This task is for testing retries", max_tries=max_tries, delay=delay, delay_max=delay_max
+    )

--- a/boilermaker/sample.py
+++ b/boilermaker/sample.py
@@ -19,7 +19,9 @@ STATIC_DEBUG_TASK = Task.default(TASK_NAME, acks_late=False)
 STATIC_DEBUG_TASK.payload = {"args": [], "kwargs": {}}
 
 
-async def debug_task_retry_policy(state, use_default: bool, msg: str = "RETRY TEST", max_tries=5, delay=30, delay_max=600):
+async def debug_task_retry_policy(
+    state, use_default: bool, msg: str = "RETRY TEST", max_tries=5, delay=30, delay_max=600
+):
     """
     This task does nothing.
     """

--- a/boilermaker/sample.py
+++ b/boilermaker/sample.py
@@ -1,6 +1,6 @@
 import logging
 
-from .retries import RetryExceptionDefaultExponential
+from .retries import RetryException, RetryExceptionDefaultExponential
 from .task import Task
 
 logger = logging.getLogger(__name__)
@@ -19,10 +19,13 @@ STATIC_DEBUG_TASK = Task.default(TASK_NAME, acks_late=False)
 STATIC_DEBUG_TASK.payload = {"args": [], "kwargs": {}}
 
 
-async def debug_task_retry_policy(state, max_tries=5, delay=30, delay_max=600):
+async def debug_task_retry_policy(state, use_default: bool, max_tries=5, delay=30, delay_max=600):
     """
     This task does nothing
     """
+    msg = "RETRY TEST"
+    if use_default:
+        raise RetryException(msg)
     raise RetryExceptionDefaultExponential(
-        "This task is for testing retries", max_tries=max_tries, delay=delay, delay_max=delay_max
+        msg, max_tries=max_tries, delay=delay, delay_max=delay_max
     )

--- a/boilermaker/sample.py
+++ b/boilermaker/sample.py
@@ -19,11 +19,10 @@ STATIC_DEBUG_TASK = Task.default(TASK_NAME, acks_late=False)
 STATIC_DEBUG_TASK.payload = {"args": [], "kwargs": {}}
 
 
-async def debug_task_retry_policy(state, use_default: bool, max_tries=5, delay=30, delay_max=600):
+async def debug_task_retry_policy(state, use_default: bool, msg: str = "RETRY TEST", max_tries=5, delay=30, delay_max=600):
     """
-    This task does nothing
+    This task does nothing.
     """
-    msg = "RETRY TEST"
     if use_default:
         raise RetryException(msg)
     raise RetryExceptionDefaultExponential(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boilermaker-servicebus"
-version = "0.5.1a1"
+version = "0.6.0"
 description = "An async python Background task system using Azure Service Bus Queues"
 authors = [
     { "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" },

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,3 @@
-import json
 import random
 
 import pytest

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -121,7 +121,7 @@ async def test_create_task_with_policy(app):
 
     # Function must be registered first: use default policy
     app.register_async(somefunc, policy=retries.RetryPolicy.default())
-    # Sanity check: default policy shuold be higher than what we're setting below
+    # Sanity check: default policy should be higher than what we're setting below
     assert app.task_registry["somefunc"].policy.max_tries > 2
     # Now we can create a task out of it
     policy = retries.RetryPolicy(

--- a/uv.lock
+++ b/uv.lock
@@ -260,7 +260,7 @@ wheels = [
 
 [[package]]
 name = "boilermaker-servicebus"
-version = "0.5.1a1"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aio-azure-clients-toolbox" },

--- a/uv.lock
+++ b/uv.lock
@@ -260,7 +260,7 @@ wheels = [
 
 [[package]]
 name = "boilermaker-servicebus"
-version = "0.5.0a1"
+version = "0.5.1a1"
 source = { editable = "." }
 dependencies = [
     { name = "aio-azure-clients-toolbox" },


### PR DESCRIPTION
One of the elements of this library that we haven't evaluated closely enough has been the retry machinery. 

`Boilermaker` allows specifying a default retry policy when registering a task, but how does that default policy get used? _Does_ it get used? If we raise a `RetryException` with a different policy than the task was registered with, does the _different policy_ get used? 

Current problems are:

- If we raise a `RetryException` with a different policy than the task was registered with, this new policy will get ignored in favor of the existing default on the task.
- We can't _publish_ a task with a different policy than it was registered with.
- The `apply_async` method has a confusing `retries` kwarg: this has nothing to do with the `RetryPolicy` on the task.

This library is confused and confusing in this area, so this PR is attempting to sort this out. 

There are three scenarios now where retry policies can be set and respected by the app. The following is excerpted from the Updated Readme (see files changed):

> ### Retries
> Retries are configured in `Boilermaker` using a `RetryPolicy`...
>
> Retries are __scheduled__ only by raising a `RetryException`...
>
> __Note__: _all_ tasks __must__ be registered with a `RetryPolicy`, but `Boilermaker` will only retry tasks that have raised a `RetryException`.
>
> If you do not want your tasks to be retried:
>
> - Do not throw a `RetryException` from inside of your task.
> - Register them with a `NoRetry` policy: `worker.register_async(..., policy=retries.NoRetry())`
>
> `NoRetry()` is simply a special policy where `max_tries=1`.
>
> __Note__: `on_failure` callbacks will only be run __after all retries have been exhausted__.

> There are three places where retries for a task can be configured:

> - When initially registering a task (the task default).
> - When scheduling a task (override the default).
> - When raising a `RetryException` in order to trigger a retry (also overrides the default).

## Potential Sources of Confusion in the Future

It's possible that a task could continually set a different `max_tries` each time it raises, which _could_ continually raise the bar for `max_tries`. (It should always respect and preserve the `attempts`.)

## Additional Changes

- Modify `apply_async(..., retries=3...)` kwarg to be  `apply_async(..., publish_retries=3...)` for multiple publish attempts.