### PR TITLE
Add renew_message_lock method to Boilermaker

### DIFF
--- a/boilermaker/app.py
+++ b/boilermaker/app.py
@@ -99,6 +99,7 @@ class Boilermaker:
         self.function_registry: dict[str, typing.Any] = {}
         self.task_registry: dict[str, Task] = {}
         self._current_message: ServiceBusReceivedMessage | None = None
+        self._receiver: ServiceBusReceiver | None = None
 
     # ~~ ** Task Registration and Publishing ** ~~
     def task(self, **options):
@@ -395,6 +396,7 @@ class Boilermaker:
                         )
                         logger.error(msg)
                     self._current_message = None
+                    self._receiver = None
                     logger.warning(
                         f"Signal {signum=} received: shutting down. "
                         f"Msg returned to queue {sequence_number=}"
@@ -434,7 +436,9 @@ class Boilermaker:
             async with self.service_bus_client.get_receiver() as receiver:
                 # Handle SIGTERM: when found, agbandon message
                 tg.start_soon(self.signal_handler, receiver, tg.cancel_scope)
-
+                # Keep reference to receiver for lock renewals
+                self._receiver = receiver
+                # Main message loop
                 async for msg in receiver:
                     # This separate method is easier to test
                     # and easier to early-return from in case of skip or fail msg
@@ -458,6 +462,24 @@ class Boilermaker:
             )
             logger.error(logmsg)
         self._current_message = None
+
+    async def renew_message_lock(self) -> None:
+        """Renew the lock on the current message being processed."""
+        if self._receiver is None:
+            logger.warning("No receiver to renew lock for")
+            return None
+        if self._current_message is None:
+            logger.warning("No current message to renew lock for")
+            return None
+
+        try:
+            await self._receiver.renew_message_lock(self._current_message)
+        except (MessageLockLostError, ServiceBusError, SessionLockLostError):
+            logmsg = (
+                f"Failed to renew message lock sequence_number={self._current_message.sequence_number} "
+                f"exc_info={traceback.format_exc()}"
+            )
+            logger.error(logmsg)
 
     async def message_handler(
         self, msg: ServiceBusReceivedMessage, receiver: ServiceBusReceiver

--- a/docs/api-reference/app.md
+++ b/docs/api-reference/app.md
@@ -5,3 +5,35 @@
       show_root_heading: true
       show_source: true
       heading_level: 2
+
+## Message Lock Renewal
+
+For long-running tasks that may exceed Azure Service Bus message lock duration, use `renew_message_lock()` to maintain exclusive access to the message:
+
+```python
+@app.task()
+async def process_large_file(state, file_path: str):
+    """Process a large file with periodic lock renewal."""
+
+    lines = await read_file_lines(file_path)
+
+    for i, line in enumerate(lines):
+        await process_line(line)
+
+        # Renew message lock every 50 lines
+        if i % 50 == 0:
+            await state.app.renew_message_lock()
+
+    return f"Processed {len(lines)} lines"
+```
+
+!!! note "When to Use"
+    Use message lock renewal for tasks that:
+
+    - Process large datasets or files
+    - Make multiple external API calls
+    - Perform complex computations taking several minutes
+    - Cannot be easily broken into smaller tasks
+
+!!! warning "Lock Duration Limits"
+    Azure Service Bus has maximum lock duration limits. For extremely long operations, consider breaking them into smaller, chainable tasks instead.

--- a/docs/api-reference/app.md
+++ b/docs/api-reference/app.md
@@ -8,7 +8,7 @@
 
 ## Message Lock Renewal
 
-For long-running tasks that may exceed Azure Service Bus message lock duration, use `renew_message_lock()` to maintain exclusive access to the message:
+For long-running tasks that may exceed Azure Service Bus message lock duration, it's possible to use `renew_message_lock()` to maintain exclusive access to the message (and prevent it from being redelivered):
 
 ```python
 @app.task()
@@ -27,13 +27,7 @@ async def process_large_file(state, file_path: str):
     return f"Processed {len(lines)} lines"
 ```
 
-!!! note "When to Use"
-    Use message lock renewal for tasks that:
+!!! note "More information"
+    Use message lock renewal for tasks that take longer than the message-lease duration for your queue.
 
-    - Process large datasets or files
-    - Make multiple external API calls
-    - Perform complex computations taking several minutes
-    - Cannot be easily broken into smaller tasks
-
-!!! warning "Lock Duration Limits"
-    Azure Service Bus has maximum lock duration limits. For extremely long operations, consider breaking them into smaller, chainable tasks instead.
+    Consult the [Azure documentation](https://learn.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock) for more information.

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -71,6 +71,11 @@ async def long_running_task(state, data_file: str):
     return f"Processed {len(items)} items"
 ```
 
+!!! note "More information"
+    Use message lock renewal for tasks that take longer than the message-lease duration for your queue.
+
+    Consult the [Azure documentation](https://learn.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock) for more information.
+
 ## Success/Failure Callbacks
 
 Chain tasks for error handling workflows.

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -51,6 +51,26 @@ async def resilient_task(state, data: dict):
         return {"status": "failed", "error": str(e)}
 ```
 
+## Message Lock Renewal for Long Tasks
+
+For long-running tasks that may exceed the Azure Service Bus message lock duration, renew the lock periodically:
+
+```python
+@app.task()
+async def long_running_task(state, data_file: str):
+    """Process large dataset with lock renewal."""
+    items = await load_large_dataset(data_file)
+
+    for i, item in enumerate(items):
+        await process_item(item)
+
+        # Renew lock every 100 items to prevent timeout
+        if i % 100 == 0:
+            await state.app.renew_message_lock()
+
+    return f"Processed {len(items)} items"
+```
+
 ## Success/Failure Callbacks
 
 Chain tasks for error handling workflows.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boilermaker-servicebus"
-version = "0.7.2"
+version = "0.8.0"
 description = "An async python Background task system using Azure Service Bus Queues"
 authors = [{ "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" }]
 license = { file = "LICENSE" }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -531,7 +531,7 @@ async def test_renew_message_lock(app, mockservicebus):
 
 
 async def test_renew_message_lock_errors(app, mockservicebus):
-    """Test that renew_message_lock is called with the correct message."""
+    """Test that renew_message_lock handles errors gracefully."""
     msg = DummyMsg()
     app._current_message = msg
     receiver = mockservicebus._receiver

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -11,7 +11,7 @@ from anyio import create_task_group, to_thread
 from azure.servicebus import ServiceBusReceivedMessage
 from azure.servicebus._common.constants import SEQUENCENUBMERNAME
 from azure.servicebus._pyamqp.message import Message
-from azure.servicebus.exceptions import ServiceBusError
+from azure.servicebus.exceptions import MessageLockLostError, ServiceBusError
 from boilermaker import failure, retries
 from boilermaker.app import Boilermaker, BoilermakerAppException
 from boilermaker.task import Task
@@ -535,7 +535,7 @@ async def test_renew_message_lock_errors(app, mockservicebus):
     msg = DummyMsg()
     app._current_message = msg
     receiver = mockservicebus._receiver
-    receiver.renew_message_lock.side_effect = ServiceBusError("fail")
+    receiver.renew_message_lock.side_effect = MessageLockLostError()
     app._receiver = receiver
     await app.renew_message_lock()
     # Check that renew_message_lock was called with the correct message

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -547,7 +547,7 @@ async def test_renew_message_lock_errors(app, mockservicebus):
 
 
 async def test_renew_message_lock_missing(app, mockservicebus):
-    """Test that renew_message_lock is called with the correct message."""
+    """Test that renew_message_lock handles missing receiver or message gracefully."""
 
     msg = DummyMsg()
     app._current_message = msg

--- a/uv.lock
+++ b/uv.lock
@@ -296,7 +296,7 @@ wheels = [
 
 [[package]]
 name = "boilermaker-servicebus"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "aio-azure-clients-toolbox" },


### PR DESCRIPTION
This PR adds `renew_message_lock()` as a method on the Boilermaker app instance. To make this work, I had to store a reference to the current `receiver` object, and then we only call `renew_message_lock` for the `_current_message` (if defined).

## Tests
- Added unittests for this functionality

## Docs
- Updated documentation